### PR TITLE
style: apply forge fmt formatting to Solidity files

### DIFF
--- a/src/Asn1Decode.sol
+++ b/src/Asn1Decode.sol
@@ -262,8 +262,8 @@ library Asn1Decode {
         int256 _month = int256(month);
         int256 _day = int256(day);
 
-        int256 _days = _day - 32075 + 1461 * (_year + 4800 + (_month - 14) / 12) / 4
-            + 367 * (_month - 2 - (_month - 14) / 12 * 12) / 12 - 3 * ((_year + 4900 + (_month - 14) / 12) / 100) / 4
+        int256 _days = _day - 32075 + 1461 * (_year + 4800 + (_month - 14) / 12) / 4 + 367
+            * (_month - 2 - (_month - 14) / 12 * 12) / 12 - 3 * ((_year + 4900 + (_month - 14) / 12) / 100) / 4
             - 2440588;
 
         return ((uint256(_days) * 24 + hour) * 60 + minute) * 60 + second;

--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -104,8 +104,9 @@ contract CertManager is ICertManager {
 
         _verifyCertSignature(certificate, tbsCertPtr, parent.pubKey);
 
-        cert =
-            VerifiedCert({ca: ca, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey});
+        cert = VerifiedCert({
+            ca: ca, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey
+        });
         _saveVerified(certHash, cert);
 
         emit CertVerified(certHash);
@@ -313,11 +314,7 @@ contract CertManager is ICertManager {
         }
         bytes memory pubKey = packed.slice(0x31, packed.length - 0x31);
         return VerifiedCert({
-            ca: ca != 0,
-            notAfter: notAfter,
-            maxPathLen: maxPathLen,
-            subjectHash: subjectHash,
-            pubKey: pubKey
+            ca: ca != 0, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey
         });
     }
 }

--- a/src/ECDSA384Curve.sol
+++ b/src/ECDSA384Curve.sol
@@ -23,13 +23,7 @@ library ECDSA384Curve {
 
     function p384() internal pure returns (ECDSA384.Parameters memory) {
         return ECDSA384.Parameters({
-            a: CURVE_A,
-            b: CURVE_B,
-            gx: CURVE_GX,
-            gy: CURVE_GY,
-            p: CURVE_P,
-            n: CURVE_N,
-            lowSmax: CURVE_LOW_S_MAX
+            a: CURVE_A, b: CURVE_B, gx: CURVE_GX, gy: CURVE_GY, p: CURVE_P, n: CURVE_N, lowSmax: CURVE_LOW_S_MAX
         });
     }
 }


### PR DESCRIPTION
## Summary
Applied consistent code formatting using `forge fmt` to ensure all Solidity files conform to the project's formatting standards.

## Changes
Formatted 3 files:
- `src/Asn1Decode.sol`
- `src/CertManager.sol`
- `src/ECDSA384Curve.sol`

## Why
Consistent formatting improves code readability and ensures CI checks pass when `forge fmt --check` is run.