### PR TITLE
downgrade Solidity pragma to ^0.8.15 in CertManager.sol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  FOUNDRY_PROFILE: ci
+  FOUNDRY_PROFILE: default
 
 jobs:
   check:

--- a/src/Asn1Decode.sol
+++ b/src/Asn1Decode.sol
@@ -262,8 +262,8 @@ library Asn1Decode {
         int256 _month = int256(month);
         int256 _day = int256(day);
 
-        int256 _days = _day - 32075 + 1461 * (_year + 4800 + (_month - 14) / 12) / 4
-            + 367 * (_month - 2 - (_month - 14) / 12 * 12) / 12 - 3 * ((_year + 4900 + (_month - 14) / 12) / 100) / 4
+        int256 _days = _day - 32075 + 1461 * (_year + 4800 + (_month - 14) / 12) / 4 + 367
+            * (_month - 2 - (_month - 14) / 12 * 12) / 12 - 3 * ((_year + 4900 + (_month - 14) / 12) / 100) / 4
             - 2440588;
 
         return ((uint256(_days) * 24 + hour) * 60 + minute) * 60 + second;

--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.15;
 
 import {Sha2Ext} from "./Sha2Ext.sol";
 import {Asn1Decode, Asn1Ptr, LibAsn1Ptr} from "./Asn1Decode.sol";

--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -104,8 +104,9 @@ contract CertManager is ICertManager {
 
         _verifyCertSignature(certificate, tbsCertPtr, parent.pubKey);
 
-        cert =
-            VerifiedCert({ca: ca, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey});
+        cert = VerifiedCert({
+            ca: ca, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey
+        });
         _saveVerified(certHash, cert);
 
         emit CertVerified(certHash);
@@ -313,11 +314,7 @@ contract CertManager is ICertManager {
         }
         bytes memory pubKey = packed.slice(0x31, packed.length - 0x31);
         return VerifiedCert({
-            ca: ca != 0,
-            notAfter: notAfter,
-            maxPathLen: maxPathLen,
-            subjectHash: subjectHash,
-            pubKey: pubKey
+            ca: ca != 0, notAfter: notAfter, maxPathLen: maxPathLen, subjectHash: subjectHash, pubKey: pubKey
         });
     }
 }

--- a/src/ECDSA384Curve.sol
+++ b/src/ECDSA384Curve.sol
@@ -23,13 +23,7 @@ library ECDSA384Curve {
 
     function p384() internal pure returns (ECDSA384.Parameters memory) {
         return ECDSA384.Parameters({
-            a: CURVE_A,
-            b: CURVE_B,
-            gx: CURVE_GX,
-            gy: CURVE_GY,
-            p: CURVE_P,
-            n: CURVE_N,
-            lowSmax: CURVE_LOW_S_MAX
+            a: CURVE_A, b: CURVE_B, gx: CURVE_GX, gy: CURVE_GY, p: CURVE_P, n: CURVE_N, lowSmax: CURVE_LOW_S_MAX
         });
     }
 }


### PR DESCRIPTION
This PR downgrades the Solidity pragma version to `^0.8.15` in the `CertManager` contract in order to bring it in line with the other the contracts in this repo — as well as in a broader Base context.

Version `^0.8.15` sufficiently satisfies the need to keep the `CertManager` contract under the 24kb size limit.