### PR TITLE
fix: support indefinite-length CBOR maps in attestation decoding

### DIFF
--- a/src/CborDecode.sol
+++ b/src/CborDecode.sol
@@ -110,6 +110,10 @@ library CborDecode {
             return LibCborElement.toCborElement(_type | ai, ix + 1, 0);
         }
         require(_type == expectedType, "unexpected type");
+        if (ai == 31) {
+            // Indefinite-length map or array (0xBF, 0x9F) — count unknown
+            return LibCborElement.toCborElement(_type, ix + 1, 0);
+        }
         require(ai < 28, "unsupported type");
         if (ai == 24) {
             return LibCborElement.toCborElement(_type, ix + 2, uint8(cbor[ix + 1]));

--- a/src/NitroValidator.sol
+++ b/src/NitroValidator.sol
@@ -153,6 +153,8 @@ contract NitroValidator {
         Ptrs memory ptrs;
         uint256 end = payload.end();
         while (current.end() < end) {
+            // Break marker (0xFF) terminates indefinite-length maps
+            if (uint8(attestationTbs[current.end()]) == 0xff) break;
             current = attestationTbs.nextTextString(current);
             bytes32 keyHash = attestationTbs.keccak(current);
             if (keyHash == MODULE_ID_KEY) {


### PR DESCRIPTION
## Summary

Some AWS Nitro Enclave attestation documents use **indefinite-length CBOR maps** (major type 5, additional info 31 = `0xBF`), which the current decoder does not support. This causes `validateAttestation` to revert with `"unsupported type"` when processing some attestations with indefinitely length fields.

This PR adds two small fixes:

- **`CborDecode.sol`**: Handle `ai == 31` (indefinite-length) in `peekType` — return an element with count 0 and advance past the marker byte, consistent with how other special `ai` values are handled.
- **`NitroValidator.sol`**: Detect the CBOR break marker (`0xFF`) in the attestation map parsing loop to correctly terminate iteration over indefinite-length maps.

## Context

Per [RFC 8949 §3.2.1](https://www.rfc-editor.org/rfc/rfc8949#section-3.2.1), CBOR maps may use either definite-length encoding (`0xA0`–`0xB7`) or indefinite-length encoding (`0xBF`), terminated by a break code (`0xFF`). AWS Nitro attestation documents use the indefinite-length form for the top-level attestation map.

Discovered while building the [EIP-8004 TEE Registry reference implementation](https://github.com/sparsity-xyz/8004-tee-registry-ri), which uses `nitro-validator` for on-chain Nitro attestation verification on Base Sepolia.

## Test plan

- Verified against real Nitro attestation documents from running AWS Nitro Enclaves
- Successfully deployed and registered TEE instances on Base Sepolia using patched library
- Registration tx (18.6M gas, warm certs): [0x887adc15...](https://sepolia.basescan.org/tx/0x887adc15bda6b6fb8856d5f036a49690d6beb72871f52d171da9deb737c296fa)