### PR TITLE
 fix _loadVerified assembly offsets in CertManager

### DIFF
--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -518,10 +518,10 @@ contract CertManager is ICertManager {
         int64 maxPathLen;
         bytes32 subjectHash;
         assembly {
-            ca := mload(add(packed, 0x1))
-            notAfter := mload(add(packed, 0x9))
-            maxPathLen := mload(add(packed, 0x11))
-            subjectHash := mload(add(packed, 0x31))
+            ca := byte(0, mload(packed))
+            notAfter := shr(192, mload(add(packed, 0x01)))
+            maxPathLen := shr(192, mload(add(packed, 0x09)))
+            subjectHash := mload(add(packed, 0x11))
         }
         bytes memory pubKey = packed.slice(0x31, packed.length - 0x31);
         return VerifiedCert({


### PR DESCRIPTION
  _loadVerified was reading fields from wrong byte offsets in the packed certificate metadata. abi.encodePacked lays out the fields as:

      ca(1) || notAfter(8) || maxPathLen(8) || subjectHash(32) || pubKey(48)

    The assembly code was reading from:
      ca at offset 0x1 should be 0x0
      notAfter at offset 0x9 should be 0x1
      maxPathLen at offset 0x11 should be 0x9
      subjectHash at offset 0x31 should be 0x11

    Only pubKey was correct since it uses slice() which starts at the right offset.

    The warm cache path calls _loadVerified for every cert that has been previously verified. With these wrong offsets, every cached cert returns garbage values for ca, notAfter, maxPathLen and subjectHash. The notAfter being wrong means expiry checks in the warm path are comparing against random bytes rather than the actual certificate expiry date. The subjectHash being wrong means parent chain validation can fail or worse silently pass when it should not.

    This also affects the NitroValidator flow since verifyCachedCertBundle relies on the warm cache path via verifyCACertWithHints and verifyClientCertWithHints.