### PR TITLE
test: cover trailing cert bytes cache poisoning guard

### DIFF
--- a/test/hinted/HintedNitroAttestation.t.sol
+++ b/test/hinted/HintedNitroAttestation.t.sol
@@ -478,6 +478,29 @@ contract HintedNitroAttestationTest is Test {
         certManager.verifyCACertWithHints(abi.encodePacked(caCert, bytes1(0x00)), parentHash, "");
     }
 
+    function test_HintedTrailingRootBytesCannotPoisonParentCache() public {
+        bytes memory attestation = _repairMissingPublicKeyBytes(_decodeBase64(_realAttestationB64()));
+        (bytes memory attestationTbs,) = validator.decodeAttestationTbs(attestation);
+        NitroValidator.Ptrs memory ptrs = parser.parseAttestation(attestationTbs);
+
+        bytes memory rootCert = attestationTbs.slice(ptrs.cabundle[0]);
+        bytes memory caCert = attestationTbs.slice(ptrs.cabundle[1]);
+        bytes32 rootHash = keccak256(rootCert);
+        assertEq(rootHash, certManager.ROOT_CA_CERT_HASH(), "expected pinned AWS Nitro root");
+
+        bytes memory shadowRoot = abi.encodePacked(rootCert, bytes1(0x00));
+        bytes32 shadowRootHash = keccak256(shadowRoot);
+        bytes memory shadowRootHints =
+            hintCollector.collectCertSignatureHints(shadowRoot, certManager.loadVerified(rootHash).pubKey);
+
+        vm.expectRevert("invalid cert length");
+        certManager.verifyCACertWithHints(shadowRoot, rootHash, shadowRootHints);
+        assertEq(certManager.loadVerified(shadowRootHash).pubKey.length, 0, "shadow root must not cache");
+
+        vm.expectRevert("parent cert unverified");
+        certManager.verifyCACertWithHints(caCert, shadowRootHash, "");
+    }
+
     function test_HintedCACertRejectsTrailingFieldInsideCertificateSequence() public {
         bytes memory attestation = _repairMissingPublicKeyBytes(_decodeBase64(_realAttestationB64()));
         (bytes memory attestationTbs,) = validator.decodeAttestationTbs(attestation);


### PR DESCRIPTION
## Summary
- Add explicit regression coverage for CAT finding `a2394309-60a7-435e-ab5b-d66efa0364e4`.
- Exercise the reported attack sequence: append trailing bytes to the AWS Nitro root cert, compute valid public P-384 hints, attempt to cache the shadow root, then attempt to verify the genuine child CA under that shadow parent.
- Assert the shadow root is not cached and the child cannot be pinned to the attacker-controlled parent hash.

## Security
Latest `main` already blocks this vector before the `verifiedParent` write: `_verifyUncachedCert` requires the outer DER object to consume the full submitted buffer, and `_verifyCertSignatureWithHints` rejects trailing fields inside the certificate sequence.

This PR locks that behavior with a focused regression test for the exact poisoning path.

## Tests
- `forge test --match-test test_HintedTrailingRootBytesCannotPoisonParentCache -vvv`
- `forge test`