### PR TITLE
fix: bound attestation CBOR container counts

### DIFF
--- a/src/NitroValidator.sol
+++ b/src/NitroValidator.sol
@@ -37,6 +37,9 @@ contract NitroValidator {
     uint256 private constant CABUNDLE_SEEN = 1 << 7;
     uint256 private constant PCRS_SEEN = 1 << 8;
 
+    uint256 public constant MAX_PCRS = 32;
+    uint256 public constant MAX_CABUNDLE_CERTS = 32;
+
     struct Ptrs {
         CborElement moduleID;
         uint64 timestamp;
@@ -123,7 +126,7 @@ contract NitroValidator {
         require(ptrs.timestamp > 0, "no timestamp");
         require(ptrs.cabundle.length > 0, "no cabundle");
         require(attestationTbs.keccak(ptrs.digest) == ATTESTATION_DIGEST, "invalid digest");
-        require(1 <= ptrs.pcrs.length && ptrs.pcrs.length <= 32, "invalid pcrs");
+        require(1 <= ptrs.pcrs.length && ptrs.pcrs.length <= MAX_PCRS, "invalid pcrs");
         require(
             ptrs.publicKey.isNull() || (1 <= ptrs.publicKey.length() && ptrs.publicKey.length() <= 1024),
             "invalid pub key"
@@ -204,7 +207,8 @@ contract NitroValidator {
     ///        AWS's COSE signature, so unknown content is signed and ignoring it cannot change the
     ///        accept decision.
     ///      - The outer payload map and the nested `pcrs` map / `cabundle` array are each accepted in
-    ///        both definite-length and indefinite-length CBOR form.
+    ///        both definite-length and indefinite-length CBOR form. Parser-time count caps are applied
+    ///        before allocation, so malformed pre-auth payloads cannot force unbounded memory growth.
     ///      - Recognised top-level keys are single-assignment and the payload must be fully consumed,
     ///        so duplicate security-critical fields or signed-but-unparsed trailing bytes revert.
     function _parseAttestation(bytes memory attestationTbs) internal pure returns (Ptrs memory) {
@@ -306,6 +310,7 @@ contract NitroValidator {
         current = tbs.nextArray(keyPtr);
         bool indefinite = _isIndefinite(tbs, headerIx);
         uint256 count = indefinite ? _countIndefiniteItems(tbs, current.end()) : current.value();
+        require(count <= MAX_CABUNDLE_CERTS, "too many cabundle certs");
         cabundle = new CborElement[](count);
         for (uint256 i = 0; i < count; i++) {
             current = tbs.nextByteString(current);
@@ -336,6 +341,7 @@ contract NitroValidator {
         } else {
             count = current.value();
         }
+        require(count <= MAX_PCRS, "too many pcrs");
         pcrs = new CborElement[](count);
         for (uint256 i = 0; i < count; i++) {
             current = tbs.nextPositiveInt(current);

--- a/test/IndefiniteLengthCbor.t.sol
+++ b/test/IndefiniteLengthCbor.t.sol
@@ -862,6 +862,36 @@ contract NitroValidatorIndefiniteLengthTest is Test {
         validator.parseAttestation(tbs);
     }
 
+    /// @dev Malicious definite-length cabundle count must be bounded before allocating the pointer
+    ///      array. This is the 34-byte payload shape from the gas-grief finding.
+    function test_neg_largeCabundleCount_revertsBeforeAllocation() public {
+        bytes memory tbs = _buildTbs(
+            abi.encodePacked(
+                hex"a1", // one top-level map entry
+                hex"68636162756e646c65", // key "cabundle"
+                hex"9a000fffff" // array(1,048,575)
+            )
+        );
+        assertEq(tbs.length, 34, "expected minimal large-cabundle payload");
+
+        vm.expectRevert("too many cabundle certs");
+        validator.parseAttestation(tbs);
+    }
+
+    /// @dev Malicious definite-length pcrs count must be bounded before allocating the pointer array.
+    function test_neg_largePcrsCount_revertsBeforeAllocation() public {
+        bytes memory tbs = _buildTbs(
+            abi.encodePacked(
+                hex"a1", // one top-level map entry
+                hex"6470637273", // key "pcrs"
+                hex"ba000fffff" // map(1,048,575)
+            )
+        );
+
+        vm.expectRevert("too many pcrs");
+        validator.parseAttestation(tbs);
+    }
+
     /// @dev Indefinite-length map without a trailing 0xFF break marker.
     ///      Parser reads past valid entries into trailing garbage, reverting
     ///      when it encounters a non-text-string byte as the next key.


### PR DESCRIPTION
## Summary
- Fix CAT finding `58c1f4c1-1da4-4fd1-94c6-6c021b57e0a3`.
- Add parser-time caps for attestation `pcrs` and `cabundle` counts before allocating `CborElement[]`.
- Reuse `MAX_PCRS = 32` for the existing PCR validation limit and add `MAX_CABUNDLE_CERTS = 32`, which is well above the current AWS Nitro 4-cert bundle.
- Add regression tests for the minimal large-count `cabundle` payload and the sibling large-count `pcrs` payload.

## Security
`validateAttestationWithHints` parses `attestationTbs` before certificate and signature verification. Before this change, a caller could set a huge definite CBOR count for `cabundle` or `pcrs`, forcing `new CborElement[](count)` to trigger quadratic memory expansion and OOG before authentication.

This change rejects excessive counts before allocation, so hostile pre-auth payloads fail with explicit bounded reverts instead of consuming the call gas limit.

## Tests
- `forge test --match-test 'test_neg_large.*Count_revertsBeforeAllocation' -vvv`
- `forge test`
