### PR TITLE
fix: bound JS CBOR parsing depth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           node --check tools/nitro_attestation_input.js
           node --check tools/hinted_attestation_calls.js
+          node --test tools/p384_hints.test.js
           node tools/nitro_attestation_input.js fixture > /dev/null
           node tools/hinted_attestation_calls.js fixture > /dev/null
         id: tools

--- a/tools/p384_hints.js
+++ b/tools/p384_hints.js
@@ -12,6 +12,7 @@ const B = hexToBigInt("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5
 const GX = hexToBigInt("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7");
 const GY = hexToBigInt("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f");
 const MASK_256 = (1n << 256n) - 1n;
+const MAX_CBOR_NESTING_DEPTH = 128;
 
 if (require.main === module) {
   main();
@@ -612,7 +613,11 @@ function parseAttestationPayload(attestation) {
   return result;
 }
 
-function readCborItem(bytes, start) {
+function readCborItem(bytes, start, depth = 0) {
+  if (depth > MAX_CBOR_NESTING_DEPTH) {
+    throw new Error("CBOR nesting depth exceeded");
+  }
+
   const initial = bytes[start];
   if (initial === undefined) {
     throw new Error("CBOR read out of bounds");
@@ -635,12 +640,12 @@ function readCborItem(bytes, start) {
         if (end >= bytes.length) {
           throw new Error("indefinite CBOR array missing break");
         }
-        end = readCborItem(bytes, end).end;
+        end = readCborItem(bytes, end, depth + 1).end;
       }
       end++;
     } else {
       for (let i = 0n; i < value; ++i) {
-        end = readCborItem(bytes, end).end;
+        end = readCborItem(bytes, end, depth + 1).end;
       }
     }
   } else if (major === 5) {
@@ -650,14 +655,14 @@ function readCborItem(bytes, start) {
         if (end >= bytes.length) {
           throw new Error("indefinite CBOR map missing break");
         }
-        const key = readCborItem(bytes, end);
-        const mapValue = readCborItem(bytes, key.end);
+        const key = readCborItem(bytes, end, depth + 1);
+        const mapValue = readCborItem(bytes, key.end, depth + 1);
         end = mapValue.end;
       }
       end++;
     } else {
       for (let i = 0n; i < value * 2n; ++i) {
-        end = readCborItem(bytes, end).end;
+        end = readCborItem(bytes, end, depth + 1).end;
       }
     }
   } else if (major === 0 || major === 1 || major === 6 || major === 7) {
@@ -750,6 +755,7 @@ function hexToBigInt(hex) {
 }
 
 module.exports = {
+  MAX_CBOR_NESTING_DEPTH,
   collectAttestationHintBytes,
   collectCertSignatureHintBytes,
   collectVerifyHintBytes,

--- a/tools/p384_hints.test.js
+++ b/tools/p384_hints.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const assert = require("assert");
+const test = require("node:test");
+
+const { MAX_CBOR_NESTING_DEPTH, parseAttestationSignature } = require("./p384_hints");
+
+test("parseAttestationSignature rejects excessive CBOR nesting", () => {
+  const protectedHeader = Buffer.from([0x44, 0xa1, 0x01, 0x38, 0x22]);
+  const unprotectedHeaderPrefix = Buffer.from([0xa1, 0x00]);
+  const nestedArrays = Buffer.alloc(MAX_CBOR_NESTING_DEPTH + 1, 0x81);
+  const terminalItem = Buffer.from([0x00]);
+  const attestation = Buffer.concat([
+    Buffer.from([0x84]),
+    protectedHeader,
+    unprotectedHeaderPrefix,
+    nestedArrays,
+    terminalItem,
+  ]);
+
+  assert.throws(
+    () => parseAttestationSignature(attestation),
+    (err) =>
+      err instanceof Error && !(err instanceof RangeError) && err.message === "CBOR nesting depth exceeded",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes CAT finding `5cc62713-40c6-44c6-9d65-8da6226c7a47`.

`tools/p384_hints.js` includes a recursive reference CBOR parser used by the CLI and FFI hint-generation tooling. A deeply nested CBOR array/map structure could previously recurse until V8 threw `RangeError: Maximum call stack size exceeded`.

This change:

- adds a `MAX_CBOR_NESTING_DEPTH` guard to `readCborItem`;
- increments the depth counter for array and map children;
- returns a normal `Error("CBOR nesting depth exceeded")` before the JS stack can overflow;
- adds a no-dependency Node test that constructs the malicious COSE shape and asserts the bounded parser error is raised instead of `RangeError`;
- wires that test into the existing off-chain tooling CI smoke step.

## Self Review

Reviewed the final diff before opening this PR. The change is scoped to non-production reference tooling, preserves existing fixture generation and FFI parity, and only changes malformed deeply nested CBOR behavior from stack exhaustion to a catchable parser error.

## Tests

- `node --test tools/p384_hints.test.js`
- `node --check tools/p384_hints.js`
- `node --check tools/hinted_attestation_calls.js`
- `node --check tools/nitro_attestation_input.js`
- `node tools/nitro_attestation_input.js fixture`
- `node tools/hinted_attestation_calls.js fixture`
- `NITRO_RUN_FFI=true forge test --ffi -vvv --match-test test_OffchainWitness`
- `forge test`
