### PR TITLE
fix: fail closed on broken cached cert chain (L-01)

### DIFF
--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -229,6 +229,10 @@ contract CertManager is ICertManager {
             }
             certHash = verifiedParent[certHash];
         }
+        // Fail closed: a chain that terminates at bytes32(0) without reaching the pinned root is
+        // broken and must not be treated as a verified, non-revoked chain. Reverting here instead
+        // of returning silently means revocation safety never depends on upstream guards.
+        revert("incomplete cert chain");
     }
 
     function _verifyCert(

--- a/test/CertManager.t.sol
+++ b/test/CertManager.t.sol
@@ -156,3 +156,52 @@ contract CertManagerTest is Test {
         return der;
     }
 }
+
+/// @dev Exposes the internal revocation-chain walk and lets tests seed the `verifiedParent`
+///      cache directly so the broken-chain (fail-closed) behaviour can be exercised in isolation.
+contract RevocationChainHarness is CertManager {
+    constructor() CertManager(new P384Verifier()) {}
+
+    function setParent(bytes32 child, bytes32 parent) external {
+        verifiedParent[child] = parent;
+    }
+
+    function requireCachedChainNotRevoked(bytes32 certHash) external view {
+        _requireCachedChainNotRevoked(certHash);
+    }
+}
+
+/// @dev Regression coverage for BLOCKSEC-5249 finding L-01: `_requireCachedChainNotRevoked`
+///      previously fell through and returned silently when a cached chain terminated at
+///      bytes32(0) without reaching the pinned root, i.e. it failed open on a broken chain.
+contract RequireCachedChainNotRevokedTest is Test {
+    RevocationChainHarness internal cm;
+
+    bytes32 internal constant CHILD = bytes32(uint256(1));
+    bytes32 internal constant PARENT = bytes32(uint256(2));
+
+    function setUp() public {
+        cm = new RevocationChainHarness();
+    }
+
+    function test_PassesWhenChainReachesPinnedRoot() public {
+        bytes32 root = cm.ROOT_CA_CERT_HASH();
+        cm.setParent(CHILD, PARENT);
+        cm.setParent(PARENT, root);
+        // Walks CHILD -> PARENT -> ROOT and returns without reverting.
+        cm.requireCachedChainNotRevoked(CHILD);
+    }
+
+    function test_RevertsWhenChainDoesNotReachRoot() public {
+        // verifiedParent[PARENT] is unset (bytes32(0)), so the chain is broken: it can never
+        // reach ROOT_CA_CERT_HASH. The fixed function must fail closed instead of returning.
+        cm.setParent(CHILD, PARENT);
+        vm.expectRevert("incomplete cert chain");
+        cm.requireCachedChainNotRevoked(CHILD);
+    }
+
+    function test_RevertsOnZeroCertHash() public {
+        vm.expectRevert("incomplete cert chain");
+        cm.requireCachedChainNotRevoked(bytes32(0));
+    }
+}


### PR DESCRIPTION
## Doc finding — L-01 (Low): Fail-open in `_requireCachedChainNotRevoked`

From the **BLOCKSEC-5249: Nitro Validator post-Fusaka review** audit (finding **L-01**):

> `_requireCachedChainNotRevoked` will fail open in the event that the parent cert hash returned is `bytes32(0)`. While this cannot happen in practice due to other guards that exist, this function will fail-open in the event that a broken certificate chain is provided. This means it relies on other composite checks to occur instead of failing closed.
>
> **Recommendation:** If the while loop breaks out due to the parent cert being `bytes32(0)` (i.e. the certificate chain is broken), the function should revert instead of silently returning.

## The bug

```solidity
function _requireCachedChainNotRevoked(bytes32 certHash) internal view {
    while (certHash != bytes32(0)) {
        _requireNotRevoked(_revocationKey(certHash));
        if (certHash == ROOT_CA_CERT_HASH) {
            return;
        }
        certHash = verifiedParent[certHash];
    }
    // <-- previously fell through here and returned silently
}
```

A chain that walks to `bytes32(0)` without ever reaching `ROOT_CA_CERT_HASH` is broken — it was never anchored to the pinned root. The old code returned normally in that case, so the "chain is not revoked" guarantee silently degraded into "every link we happened to walk was not revoked," relying on other call-site guards (e.g. `parent cert unverified`) to keep the broken chain from being used.

## The fix

Revert when the loop terminates without reaching the pinned root, so revocation safety fails closed and never depends on upstream guards:

```solidity
    }
    // Fail closed: a chain that terminates at bytes32(0) without reaching the pinned root is
    // broken and must not be treated as a verified, non-revoked chain.
    revert("incomplete cert chain");
}
```

The happy path is unchanged: any chain that reaches `ROOT_CA_CERT_HASH` returns exactly as before. Only the previously-silent broken-chain path now reverts.

## Tests

New `RequireCachedChainNotRevokedTest` (with a `RevocationChainHarness` that seeds `verifiedParent` directly):
- `test_PassesWhenChainReachesPinnedRoot` — `CHILD -> PARENT -> ROOT` returns without reverting.
- `test_RevertsWhenChainDoesNotReachRoot` — broken chain (`verifiedParent[PARENT] == 0`) reverts `incomplete cert chain`.
- `test_RevertsOnZeroCertHash` — calling with `bytes32(0)` reverts.

`forge fmt` + full `forge test`: **151 passed, 0 failed, 1 skipped**.