### PR TITLE
fix: bound recursive CBOR skipValue nesting depth (I-01)

### DIFF
--- a/src/CborDecode.sol
+++ b/src/CborDecode.sol
@@ -52,6 +52,13 @@ library CborDecode {
     using LibBytes for bytes;
     using LibCborElement for CborElement;
 
+    // Maximum CBOR container nesting `skipValue` will descend through before reverting. `skipValue`
+    // is recursive, so without a bound a maliciously (or accidentally) deep array/map nesting could
+    // drive recursion until execution fails on an opaque condition (stack exhaustion / out-of-gas).
+    // AWS Nitro attestation payloads nest only a few levels deep, so this generous cap never trips
+    // for real documents while keeping the recursion bounded and giving a clear revert reason.
+    uint256 internal constant MAX_CBOR_DEPTH = 64;
+
     // Calculate the keccak256 hash of the given cbor element
     function keccak(bytes memory cbor, CborElement ptr) internal pure returns (bytes32) {
         return cbor.keccak(ptr.start(), ptr.length());
@@ -101,6 +108,11 @@ library CborDecode {
     // known ahead of time — e.g. the value of an unrecognised attestation key. Out-of-bounds
     // reads (including a truncated indefinite-length container with no break marker) revert.
     function skipValue(bytes memory cbor, uint256 ix) internal pure returns (uint256) {
+        return _skipValue(cbor, ix, 0);
+    }
+
+    function _skipValue(bytes memory cbor, uint256 ix, uint256 depth) private pure returns (uint256) {
+        require(depth <= MAX_CBOR_DEPTH, "cbor nesting too deep");
         uint8 b = uint8(cbor[ix]);
         uint8 major = b >> 5;
         uint8 ai = b & 0x1f;
@@ -145,7 +157,7 @@ library CborDecode {
                 while (uint8(cbor[p]) != 0xff) {
                     uint8 chunk = uint8(cbor[p]);
                     require(chunk >> 5 == major && (chunk & 0x1f) != 31, "invalid indefinite string chunk");
-                    p = skipValue(cbor, p);
+                    p = _skipValue(cbor, p, depth + 1);
                 }
                 return p + 1;
             }
@@ -155,12 +167,12 @@ library CborDecode {
             // array
             if (indefinite) {
                 while (uint8(cbor[p]) != 0xff) {
-                    p = skipValue(cbor, p);
+                    p = _skipValue(cbor, p, depth + 1);
                 }
                 return p + 1;
             }
             for (uint64 i = 0; i < arg; i++) {
-                p = skipValue(cbor, p);
+                p = _skipValue(cbor, p, depth + 1);
             }
             return p;
         } else if (major == 5) {
@@ -169,21 +181,21 @@ library CborDecode {
                 // a map must have an even number of items (key/value pairs); a dangling key before
                 // the break marker is malformed and must revert
                 while (uint8(cbor[p]) != 0xff) {
-                    p = skipValue(cbor, p); // key
+                    p = _skipValue(cbor, p, depth + 1); // key
                     require(uint8(cbor[p]) != 0xff, "odd cbor map item count");
-                    p = skipValue(cbor, p); // value
+                    p = _skipValue(cbor, p, depth + 1); // value
                 }
                 return p + 1;
             }
             for (uint64 i = 0; i < arg; i++) {
-                p = skipValue(cbor, p);
-                p = skipValue(cbor, p);
+                p = _skipValue(cbor, p, depth + 1);
+                p = _skipValue(cbor, p, depth + 1);
             }
             return p;
         } else if (major == 6) {
             // tag: a single tagged data item follows the header
             require(!indefinite, "invalid tag encoding");
-            return skipValue(cbor, p);
+            return _skipValue(cbor, p, depth + 1);
         } else {
             // major == 7: simple value / float; ai==31 (break) is not a standalone value
             require(!indefinite, "unexpected break");

--- a/test/IndefiniteLengthCbor.t.sol
+++ b/test/IndefiniteLengthCbor.t.sol
@@ -315,6 +315,32 @@ contract CborDecodeIndefiniteLengthTest is Test {
         vm.expectRevert("odd cbor map item count");
         harness.skipValue(hex"bf01ff", 0);
     }
+
+    // ── Recursion depth bound (BLOCKSEC-5249 I-01) ────────────
+
+    /// @dev Builds `n` nested single-element definite arrays (`0x81` ...) wrapping a `0x00` leaf.
+    ///      The leaf is skipped at recursion depth `n`.
+    function _nestedArrays(uint256 n) internal pure returns (bytes memory out) {
+        out = new bytes(n + 1);
+        for (uint256 i = 0; i < n; i++) {
+            out[i] = 0x81; // array of length 1
+        }
+        out[n] = 0x00; // unsigned int 0 leaf
+    }
+
+    /// @dev Nesting whose deepest descent equals MAX_CBOR_DEPTH (64) is still accepted.
+    function test_skipValue_nestingAtLimit_succeeds() public view {
+        bytes memory deep = _nestedArrays(64);
+        assertEq(harness.skipValue(deep, 0), 65, "should consume all 65 bytes");
+    }
+
+    /// @dev One level past the limit reverts with a clear reason instead of failing on an opaque
+    ///      condition (stack exhaustion / out-of-gas) as the unbounded recursion previously could.
+    function test_skipValue_nestingOverLimit_reverts() public {
+        bytes memory tooDeep = _nestedArrays(65);
+        vm.expectRevert("cbor nesting too deep");
+        harness.skipValue(tooDeep, 0);
+    }
 }
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Doc finding — I-01 (Informational): Forward-compatible `skipValue` CBOR handler may not be completely future proof

From the **BLOCKSEC-5249: Nitro Validator post-Fusaka review** audit (finding **I-01**):

> PR#32 adds forward compatible parsing by implementing the full CBOR encoding spec in order to be able to dynamically skip over values that the Nitro Validator may not otherwise know about. [...] However, it is still possible that the Nitro Validator could fail during verification depending on the future field(s) AWS adds. Since `skipValue` is recursive there is an implicit stack depth limit of 1024 frames. In the event that an indefinite or definitive array/mapping field is added with a sufficiently large value, then it is still possible for the Nitro Validator to fail due to stack overflow when running `skipValue`.
>
> **Recommendation:** Note caveats in documentation or in comments to make sure if this situation ever does arise it will be easier to locate the root cause.

> **Note:** This finding targets the **on-chain Solidity** `skipValue` in `src/CborDecode.sol`. (PR #45 separately bounded the recursion depth of the *off-chain* JS reference parser in `tools/p384_hints.js` — a different code path.)

## The fix

Rather than only documenting the caveat, this bounds the recursion explicitly so a pathologically deep CBOR document fails with a clear, cheap revert instead of an opaque stack-exhaustion / out-of-gas condition deep inside parsing.

- Add `MAX_CBOR_DEPTH = 64` to `CborDecode` (AWS Nitro attestation payloads nest only a few levels deep, so this is far above anything a real document needs).
- `skipValue(cbor, ix)` keeps its signature and now delegates to a private recursive `_skipValue(cbor, ix, depth)`.
- Every recursive descent (arrays, maps, tags, indefinite-string chunks) passes `depth + 1`; `_skipValue` reverts `cbor nesting too deep` once `depth > MAX_CBOR_DEPTH`.

Only true **nesting** is bounded — sibling width (e.g. a wide array/map) is unaffected because siblings are skipped sequentially at the same depth (and the security-relevant `pcrs` / `cabundle` counts are independently capped elsewhere). The documenting comment requested by the finding is included on the constant.

This is liveness-only and cannot cause a false accept: the whole payload is still hashed and checked against AWS's COSE signature.

## Tests

Added to `CborDecodeIndefiniteLengthTest` (using `_nestedArrays(n)` = `n` nested single-element arrays around a leaf):
- `test_skipValue_nestingAtLimit_succeeds` — deepest descent equal to `MAX_CBOR_DEPTH` (64) still parses.
- `test_skipValue_nestingOverLimit_reverts` — one level past the cap reverts `cbor nesting too deep`.

`forge fmt` + full `forge test`: **150 passed, 0 failed, 1 skipped**.