### PR TITLE
fix: reject ambiguous cert signature wrappers

### DIFF
--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -17,6 +17,8 @@ contract CertManager is ICertManager {
     using LibAsn1Ptr for Asn1Ptr;
     using LibBytes for bytes;
 
+    error InvalidCertSignature();
+
     event CertVerified(bytes32 indexed certHash);
     event CertRevoked(bytes32 indexed certHash);
     event CertUnrevoked(bytes32 indexed certHash);
@@ -557,17 +559,17 @@ contract CertManager is ICertManager {
     function _certSignature(bytes memory certificate, Asn1Ptr sigPtr) internal pure returns (bytes memory sigPacked) {
         Asn1Ptr sigBPtr = certificate.bitstring(sigPtr);
         Asn1Ptr sigRoot = certificate.rootOf(sigBPtr);
-        require(certificate[sigRoot.header()] == 0x30, "invalid cert signature");
-        require(
-            sigRoot.header() + sigRoot.totalLength() == sigBPtr.content() + sigBPtr.length(), "invalid cert signature"
-        );
+        if (certificate[sigRoot.header()] != 0x30) revert InvalidCertSignature();
+        if (sigRoot.header() + sigRoot.totalLength() != sigBPtr.content() + sigBPtr.length()) {
+            revert InvalidCertSignature();
+        }
         Asn1Ptr sigRPtr = certificate.firstChildOf(sigRoot);
-        require(certificate[sigRPtr.header()] == 0x02, "invalid cert signature");
+        if (certificate[sigRPtr.header()] != 0x02) revert InvalidCertSignature();
         Asn1Ptr sigSPtr = certificate.nextSiblingOf(sigRPtr);
-        require(certificate[sigSPtr.header()] == 0x02, "invalid cert signature");
-        require(
-            sigSPtr.header() + sigSPtr.totalLength() == sigRoot.content() + sigRoot.length(), "invalid cert signature"
-        );
+        if (certificate[sigSPtr.header()] != 0x02) revert InvalidCertSignature();
+        if (sigSPtr.header() + sigSPtr.totalLength() != sigRoot.content() + sigRoot.length()) {
+            revert InvalidCertSignature();
+        }
         (uint128 rhi, uint256 rlo) = certificate.uint384At(sigRPtr);
         (uint128 shi, uint256 slo) = certificate.uint384At(sigSPtr);
         sigPacked = abi.encodePacked(rhi, rlo, shi, slo);

--- a/src/CertManager.sol
+++ b/src/CertManager.sol
@@ -557,8 +557,17 @@ contract CertManager is ICertManager {
     function _certSignature(bytes memory certificate, Asn1Ptr sigPtr) internal pure returns (bytes memory sigPacked) {
         Asn1Ptr sigBPtr = certificate.bitstring(sigPtr);
         Asn1Ptr sigRoot = certificate.rootOf(sigBPtr);
+        require(certificate[sigRoot.header()] == 0x30, "invalid cert signature");
+        require(
+            sigRoot.header() + sigRoot.totalLength() == sigBPtr.content() + sigBPtr.length(), "invalid cert signature"
+        );
         Asn1Ptr sigRPtr = certificate.firstChildOf(sigRoot);
+        require(certificate[sigRPtr.header()] == 0x02, "invalid cert signature");
         Asn1Ptr sigSPtr = certificate.nextSiblingOf(sigRPtr);
+        require(certificate[sigSPtr.header()] == 0x02, "invalid cert signature");
+        require(
+            sigSPtr.header() + sigSPtr.totalLength() == sigRoot.content() + sigRoot.length(), "invalid cert signature"
+        );
         (uint128 rhi, uint256 rlo) = certificate.uint384At(sigRPtr);
         (uint128 shi, uint256 slo) = certificate.uint384At(sigSPtr);
         sigPacked = abi.encodePacked(rhi, rlo, shi, slo);

--- a/test/CertManager.t.sol
+++ b/test/CertManager.t.sol
@@ -166,6 +166,38 @@ contract CertManagerTest is Test {
         cm.verifyCACertWithHints(rootTwin, rootHash, hints);
     }
 
+    function test_VerifyCACertWithHints_RejectsSignatureWrapperTagSubstitution() public {
+        vm.warp(1775145600);
+        CertManager cm = new CertManager(new P384Verifier());
+        P384HintCollector collector = new P384HintCollector();
+
+        bytes32 rootHash = keccak256(CB0);
+        bytes memory parentPubKey = cm.loadVerified(rootHash).pubKey;
+        bytes memory hints = collector.collectCertSignatureHints(CB1, parentPubKey);
+
+        bytes memory mutated = bytes.concat(CB1);
+        (,, Asn1Ptr sigRoot,) = _certSignaturePtrs(mutated);
+        mutated[sigRoot.header()] = 0x31; // constructed SET with the same r/s children.
+
+        vm.expectRevert("invalid cert signature");
+        cm.verifyCACertWithHints(mutated, rootHash, hints);
+    }
+
+    function test_VerifyCACertWithHints_RejectsTrailingSignatureFields() public {
+        vm.warp(1775145600);
+        CertManager cm = new CertManager(new P384Verifier());
+        P384HintCollector collector = new P384HintCollector();
+
+        bytes32 rootHash = keccak256(CB0);
+        bytes memory parentPubKey = cm.loadVerified(rootHash).pubKey;
+        bytes memory hints = collector.collectCertSignatureHints(CB1, parentPubKey);
+
+        bytes memory mutated = _appendSignatureTrailingField(CB1);
+
+        vm.expectRevert("invalid cert signature");
+        cm.verifyCACertWithHints(mutated, rootHash, hints);
+    }
+
     function _verifyCA(CertManager cm, P384HintCollector collector, bytes memory cert, bytes32 parentHash)
         internal
         returns (bytes32)
@@ -210,6 +242,34 @@ contract CertManagerTest is Test {
         _writeDerLength(result, root, _addDelta(root.length(), delta));
         _writeDerLength(result, sigPtr, _addDelta(sigPtr.length(), delta));
         _writeDerLength(result, sigRoot, _addDelta(sigRoot.length(), delta));
+    }
+
+    function _appendSignatureTrailingField(bytes memory certificate) internal pure returns (bytes memory result) {
+        (Asn1Ptr root, Asn1Ptr sigPtr, Asn1Ptr sigRoot,) = _certSignaturePtrs(certificate);
+        bytes memory extraInteger = hex"020100";
+        int256 delta = int256(extraInteger.length);
+        result = _insertBytes(certificate, sigRoot.content() + sigRoot.length(), extraInteger);
+
+        _writeDerLength(result, root, _addDelta(root.length(), delta));
+        _writeDerLength(result, sigPtr, _addDelta(sigPtr.length(), delta));
+        _writeDerLength(result, sigRoot, _addDelta(sigRoot.length(), delta));
+    }
+
+    function _insertBytes(bytes memory input, uint256 offset, bytes memory inserted)
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        result = new bytes(input.length + inserted.length);
+        for (uint256 i = 0; i < offset; ++i) {
+            result[i] = input[i];
+        }
+        for (uint256 i = 0; i < inserted.length; ++i) {
+            result[offset + i] = inserted[i];
+        }
+        for (uint256 i = offset; i < input.length; ++i) {
+            result[i + inserted.length] = input[i];
+        }
     }
 
     function _certSignaturePtrs(bytes memory certificate)

--- a/test/CertManager.t.sol
+++ b/test/CertManager.t.sol
@@ -179,7 +179,7 @@ contract CertManagerTest is Test {
         (,, Asn1Ptr sigRoot,) = _certSignaturePtrs(mutated);
         mutated[sigRoot.header()] = 0x31; // constructed SET with the same r/s children.
 
-        vm.expectRevert("invalid cert signature");
+        vm.expectRevert(CertManager.InvalidCertSignature.selector);
         cm.verifyCACertWithHints(mutated, rootHash, hints);
     }
 
@@ -194,7 +194,7 @@ contract CertManagerTest is Test {
 
         bytes memory mutated = _appendSignatureTrailingField(CB1);
 
-        vm.expectRevert("invalid cert signature");
+        vm.expectRevert(CertManager.InvalidCertSignature.selector);
         cm.verifyCACertWithHints(mutated, rootHash, hints);
     }
 


### PR DESCRIPTION
## Summary
- require the certificate signature BIT STRING to contain exactly one ASN.1 SEQUENCE
- require that sequence to contain exactly two INTEGER children for r and s
- reject substituted signature-wrapper tags and trailing ignored signature fields

## Security value
This closes an outside-TBS certificate malleability surface where alternate signature wrappers could be accepted and interpreted differently from strict DER/X.509 parsers.

## Tests
- forge fmt --check src test
- forge test --match-test 'test_VerifyCACertWithHints_RejectsSignatureWrapperTagSubstitution|test_VerifyCACertWithHints_RejectsTrailingSignatureFields|test_VerifyCACertWithHints_ShortS_Regression' -vvv

## Note
Latest main already fails test_DeployableContractsFitEIP170 locally with CertManager runtime bytes 24,708 > 24,576, so full-suite verification remains blocked by that pre-existing size issue.